### PR TITLE
Implemented correct attribute handling

### DIFF
--- a/src/Console/ModelsCommand.php
+++ b/src/Console/ModelsCommand.php
@@ -580,10 +580,7 @@ class ModelsCommand extends Command
                 $isAttribute = is_a($type, '\Illuminate\Database\Eloquent\Casts\Attribute', true);
                 $method = $reflection->getName();
                 if (
-                    Str::startsWith($method, 'get') && Str::endsWith(
-                        $method,
-                        'Attribute'
-                    ) && $method !== 'getAttribute'
+                    Str::startsWith($method, 'get') && Str::endsWith($method, 'Attribute') && $method !== 'getAttribute'
                 ) {
                     //Magic get<name>Attribute
                     $name = Str::snake(substr($method, 3, -9));
@@ -599,15 +596,14 @@ class ModelsCommand extends Command
                     $this->setProperty(
                         Str::snake($method),
                         $type,
-                        $types->has('get'),
-                        $types->has('set'),
+                        $types->has('get') ?: null,
+                        $types->has('set') ?: null,
                         $this->getCommentFromDocBlock($reflection)
                     );
                 } elseif (
-                    Str::startsWith($method, 'set') && Str::endsWith(
-                        $method,
-                        'Attribute'
-                    ) && $method !== 'setAttribute'
+                    Str::startsWith($method, 'set') &&
+                    Str::endsWith($method, 'Attribute') &&
+                    $method !== 'setAttribute'
                 ) {
                     //Magic set<name>Attribute
                     $name = Str::snake(substr($method, 3, -9));

--- a/tests/Console/ModelsCommand/Attributes/Models/BackedAttribute.php
+++ b/tests/Console/ModelsCommand/Attributes/Models/BackedAttribute.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Attributes\Models;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+
+class BackedAttribute extends Model
+{
+    protected function name(): Attribute
+    {
+        return new Attribute(
+            function (?string $name): ?string {
+                return $name;
+            },
+            function (?string $name): ?string {
+                return $name;
+            }
+        );
+    }
+
+    protected function nameRead(): Attribute
+    {
+        return new Attribute(
+            function (?string $name): ?string {
+                return $name;
+            },
+        );
+    }
+
+    protected function nameWrite(): Attribute
+    {
+        return new Attribute(
+            set: function (?string $name): ?string {
+                return $name;
+            },
+        );
+    }
+
+    protected function nonBackedSet(): Attribute
+    {
+        return new Attribute(
+            set: function (?string $name): ?string {
+                return $name;
+            },
+        );
+    }
+
+    protected function nonBackedGet(): Attribute
+    {
+        return new Attribute(
+            get: function (): ?string {
+                return 'test';
+            },
+        );
+    }
+}

--- a/tests/Console/ModelsCommand/Attributes/__snapshots__/Test__test__1.php
+++ b/tests/Console/ModelsCommand/Attributes/__snapshots__/Test__test__1.php
@@ -11,6 +11,83 @@ use Illuminate\Database\Eloquent\Model;
  * 
  *
  * @property int $id
+ * @property string|null $name
+ * @property string|null $name_read
+ * @property string|null $name_write
+ * @property-read string|null $non_backed_get
+ * @property-write string|null $non_backed_set
+ * @method static \Illuminate\Database\Eloquent\Builder|BackedAttribute newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|BackedAttribute newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder|BackedAttribute query()
+ * @method static \Illuminate\Database\Eloquent\Builder|BackedAttribute whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|BackedAttribute whereName($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|BackedAttribute whereNameRead($value)
+ * @method static \Illuminate\Database\Eloquent\Builder|BackedAttribute whereNameWrite($value)
+ * @mixin \Eloquent
+ */
+class BackedAttribute extends Model
+{
+    protected function name(): Attribute
+    {
+        return new Attribute(
+            function (?string $name): ?string {
+                return $name;
+            },
+            function (?string $name): ?string {
+                return $name;
+            }
+        );
+    }
+
+    protected function nameRead(): Attribute
+    {
+        return new Attribute(
+            function (?string $name): ?string {
+                return $name;
+            },
+        );
+    }
+
+    protected function nameWrite(): Attribute
+    {
+        return new Attribute(
+            set: function (?string $name): ?string {
+                return $name;
+            },
+        );
+    }
+
+    protected function nonBackedSet(): Attribute
+    {
+        return new Attribute(
+            set: function (?string $name): ?string {
+                return $name;
+            },
+        );
+    }
+
+    protected function nonBackedGet(): Attribute
+    {
+        return new Attribute(
+            get: function (): ?string {
+                return 'test';
+            },
+        );
+    }
+}
+<?php
+
+declare(strict_types=1);
+
+namespace Barryvdh\LaravelIdeHelper\Tests\Console\ModelsCommand\Attributes\Models;
+
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * 
+ *
+ * @property int $id
  * @property int $diverging_type_hinted_get_and_set
  * @property string|null $name
  * @property-read mixed $non_type_hinted_get

--- a/tests/Console/ModelsCommand/migrations/____backed_attribute_table.php
+++ b/tests/Console/ModelsCommand/migrations/____backed_attribute_table.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class BackedAttributeTable extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('backed_attributes', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('name');
+            $table->string('name_read');
+            $table->string('name_write');
+        });
+    }
+}


### PR DESCRIPTION
## Summary

Added correct handling for the Attribute class:
- If Attribute::get defined + existing corresponding DB column : @property
- If Attribute::get defined + no corresponding DB column : @property-read
- If Attribute::set defined + existing corresponding DB column : @property
- If Attribute::set defined + no corresponding DB column : @property-write
- If Attribute::get defined : @property


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] Existing tests have been adapted and/or new tests have been added
- [x] Add a CHANGELOG.md entry
- [x] Update the README.md
- [x] Code style has been fixed via `composer fix-style`
